### PR TITLE
feat: add headless BitTorrent seeder with CLI control

### DIFF
--- a/bin/libreflix
+++ b/bin/libreflix
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+require('dotenv').config();
+var http = require('http');
+
+var DAEMON_PORT = process.env.LIBREFLIX_DAEMON_PORT || 9876;
+
+function request(method, pathStr, body, cb) {
+  var data = body ? JSON.stringify(body) : null;
+  var options = {
+    hostname: 'localhost',
+    port: DAEMON_PORT,
+    path: pathStr,
+    method: method,
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': data ? Buffer.byteLength(data) : 0
+    }
+  };
+  var req = http.request(options, function(res) {
+    var chunks = '';
+    res.setEncoding('utf8');
+    res.on('data', function(c) { chunks += c; });
+    res.on('end', function() {
+      if (cb) cb(null, res.statusCode, chunks);
+    });
+  });
+  req.on('error', function(err) {
+    if (cb) cb(err);
+  });
+  if (data) req.write(data);
+  req.end();
+}
+
+function pad(str, len) {
+  str = String(str);
+  while (str.length < len) str += ' ';
+  return str;
+}
+
+function showHelp() {
+  console.log('Usage: libreflix <command> [options]');
+  console.log('');
+  console.log('Commands:');
+  console.log('  daemon                  Start the seeder daemon');
+  console.log('  list-content            List approved content from the database');
+  console.log('  seed <permalink> [q]    Tell daemon to seed content (quality: sd, hd, fhd, uhd, all)');
+  console.log('  stop <permalink> [q]    Tell daemon to stop seeding content');
+  console.log('  status                  Show active torrents from daemon');
+  console.log('');
+  console.log('Environment:');
+  console.log('  MONGODB_URI             MongoDB connection string');
+  console.log('  SEEDER_DIR              Directory to store downloads (default: ./seeder-downloads)');
+  console.log('  LIBREFLIX_DAEMON_PORT   Daemon API port (default: 9876)');
+  console.log('');
+  process.exit(1);
+}
+
+var command = process.argv[2];
+var args = process.argv.slice(3);
+
+if (!command) showHelp();
+
+function handleDaemonError(err) {
+  console.error('Error: Cannot reach daemon at localhost:' + DAEMON_PORT);
+  console.error('Start it with: libreflix daemon');
+  process.exit(1);
+}
+
+switch (command) {
+  case 'daemon':
+    require('../cli/daemon')();
+    break;
+
+  case 'list-content':
+    require('../cli/list-content')();
+    break;
+
+  case 'seed':
+    if (!args[0]) {
+      console.error('Error: missing permalink argument');
+      showHelp();
+    }
+    request('POST', '/seed', { permalink: args[0], quality: args[1] || 'all' }, function(err, code, body) {
+      if (err) return handleDaemonError(err);
+      try {
+        var data = JSON.parse(body);
+        if (data.success) {
+          data.messages.forEach(function(m) { console.log(m); });
+        } else {
+          console.error('Error:', data.error);
+          process.exit(1);
+        }
+      } catch(e) {
+        console.log(body);
+      }
+    });
+    break;
+
+  case 'stop':
+    if (!args[0]) {
+      console.error('Error: missing permalink argument');
+      showHelp();
+    }
+    request('POST', '/stop', { permalink: args[0], quality: args[1] || 'all' }, function(err, code, body) {
+      if (err) return handleDaemonError(err);
+      try {
+        var data = JSON.parse(body);
+        if (data.success) {
+          data.messages.forEach(function(m) { console.log(m); });
+        } else {
+          console.error('Error:', data.error);
+          process.exit(1);
+        }
+      } catch(e) {
+        console.log(body);
+      }
+    });
+    break;
+
+  case 'status':
+    request('GET', '/status', null, function(err, code, body) {
+      if (err) return handleDaemonError(err);
+      try {
+        var data = JSON.parse(body);
+        if (!data.success || !data.torrents.length) {
+          console.log('No active torrents.');
+          return;
+        }
+        console.log('');
+        console.log(pad('Permalink-Quality', 30) + pad('Progress', 10) + pad('Peers', 7) + pad('Down', 12) + 'Up');
+        console.log(new Array(80).join('-'));
+        data.torrents.forEach(function(t) {
+          var name = pad(t.key, 30);
+          var prog = pad(t.progress + '%', 10);
+          var peers = pad(String(t.peers), 7);
+          var down = pad((t.downloadSpeed / 1024).toFixed(1) + ' KB/s', 12);
+          var up = (t.uploadSpeed / 1024).toFixed(1) + ' KB/s';
+          console.log(name + prog + peers + down + up);
+        });
+        console.log('');
+      } catch(e) {
+        console.log(body);
+      }
+    });
+    break;
+
+  default:
+    console.error('Unknown command: ' + command);
+    showHelp();
+}

--- a/cli/daemon.js
+++ b/cli/daemon.js
@@ -1,0 +1,165 @@
+var http = require('http');
+var WebTorrent = require('webtorrent');
+var mongoose = require('mongoose');
+var path = require('path');
+var fs = require('fs');
+var Watch = require('../models/Watch');
+
+var PORT = process.env.LIBREFLIX_DAEMON_PORT || 9876;
+var DOWNLOAD_DIR = process.env.SEEDER_DIR || './seeder-downloads';
+
+if (!fs.existsSync(DOWNLOAD_DIR)) {
+  fs.mkdirSync(DOWNLOAD_DIR, { recursive: true });
+}
+
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost/libreflix', {
+  useMongoClient: true
+});
+
+var client = new WebTorrent();
+var activeTorrents = {};
+
+client.on('error', function(err) {
+  console.error('WebTorrent error:', err.message);
+});
+
+function startSeed(watch, quality, cb) {
+  var key = watch.permalink + '-' + quality;
+  if (activeTorrents[key]) {
+    return cb(null, 'Already seeding: ' + watch.title + ' (' + quality + ')');
+  }
+  var magnet = watch.magnet && watch.magnet[quality];
+  if (!magnet) {
+    return cb(null, 'No magnet link for ' + quality);
+  }
+  var savePath = path.join(DOWNLOAD_DIR, watch.permalink, quality);
+  client.add(magnet, { path: savePath }, function(torrent) {
+    activeTorrents[key] = {
+      torrent: torrent,
+      watch: watch,
+      quality: quality,
+      addedAt: Date.now()
+    };
+    var webseed = watch.webseed && watch.webseed[quality];
+    if (webseed) torrent.addWebSeed(webseed);
+    console.log('[+] Seeding:', watch.title, '(' + quality + ')');
+    torrent.on('done', function() {
+      console.log('[✓] Complete:', watch.title, '(' + quality + ')');
+    });
+    cb(null, 'Started seeding ' + watch.title + ' (' + quality + ')');
+  });
+}
+
+function stopSeed(permalink, quality, cb) {
+  var key = permalink + '-' + quality;
+  var item = activeTorrents[key];
+  if (!item) return cb(null, 'Not seeding: ' + permalink + ' (' + quality + ')');
+  client.remove(item.torrent.infoHash);
+  delete activeTorrents[key];
+  console.log('[-] Stopped:', item.watch.title, '(' + quality + ')');
+  cb(null, 'Stopped ' + item.watch.title + ' (' + quality + ')');
+}
+
+function getStatus() {
+  var out = [];
+  Object.keys(activeTorrents).forEach(function(key) {
+    var item = activeTorrents[key];
+    var t = item.torrent;
+    out.push({
+      key: key,
+      title: item.watch.title,
+      quality: item.quality,
+      progress: parseFloat((t.progress * 100).toFixed(1)),
+      peers: t.numPeers,
+      downloadSpeed: t.downloadSpeed,
+      uploadSpeed: t.uploadSpeed
+    });
+  });
+  return out;
+}
+
+var server = http.createServer(function(req, res) {
+  res.setHeader('Content-Type', 'application/json');
+  var body = '';
+  req.on('data', function(c) { body += c; });
+  req.on('end', function() {
+    var payload = {};
+    try { if (body) payload = JSON.parse(body); } catch(e) {}
+
+    function send(obj) {
+      res.end(JSON.stringify(obj));
+    }
+
+    if (req.method === 'GET' && req.url === '/status') {
+      return send({ success: true, torrents: getStatus() });
+    }
+
+    if (req.method === 'POST' && req.url === '/seed') {
+      var permalink = payload.permalink;
+      var quality = payload.quality || 'all';
+      if (!permalink) return send({ success: false, error: 'Missing permalink' });
+
+      Watch.findOne({ permalink: permalink }, function(err, watch) {
+        if (err || !watch) return send({ success: false, error: 'Content not found' });
+        var qualities = ['sd', 'hd', 'fhd', 'uhd'];
+        var available = qualities.filter(function(q) { return watch.magnet && watch.magnet[q]; });
+        if (quality !== 'all' && available.indexOf(quality) === -1) {
+          return send({ success: false, error: 'Quality not available: ' + quality });
+        }
+        var targets = (quality === 'all') ? available : [quality];
+        var pending = targets.length;
+        var messages = [];
+        targets.forEach(function(q) {
+          startSeed(watch, q, function(err, msg) {
+            messages.push(msg);
+            pending--;
+            if (pending === 0) send({ success: true, messages: messages });
+          });
+        });
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && req.url === '/stop') {
+      var permalink = payload.permalink;
+      var quality = payload.quality || 'all';
+      if (!permalink) return send({ success: false, error: 'Missing permalink' });
+
+      Watch.findOne({ permalink: permalink }, function(err, watch) {
+        if (err || !watch) return send({ success: false, error: 'Content not found' });
+        var qualities = ['sd', 'hd', 'fhd', 'uhd'];
+        var available = qualities.filter(function(q) { return watch.magnet && watch.magnet[q]; });
+        var targets = (quality === 'all') ? available : [quality];
+        var pending = targets.length;
+        var messages = [];
+        targets.forEach(function(q) {
+          stopSeed(permalink, q, function(err, msg) {
+            messages.push(msg);
+            pending--;
+            if (pending === 0) send({ success: true, messages: messages });
+          });
+        });
+      });
+      return;
+    }
+
+    res.statusCode = 404;
+    send({ success: false, error: 'Not found' });
+  });
+});
+
+mongoose.connection.once('open', function() {
+  console.log('Connected to MongoDB');
+  server.listen(PORT, function() {
+    console.log('Libreflix seeder daemon listening on port ' + PORT);
+  });
+});
+
+process.on('SIGINT', function() {
+  console.log('\nShutting down daemon...');
+  client.destroy(function() {
+    mongoose.connection.close(function() {
+      process.exit(0);
+    });
+  });
+});

--- a/cli/list-content.js
+++ b/cli/list-content.js
@@ -1,0 +1,47 @@
+var mongoose = require('mongoose');
+var Watch = require('../models/Watch');
+
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost/libreflix', {
+  useMongoClient: true
+});
+
+function pad(str, len) {
+  str = String(str);
+  while (str.length < len) str += ' ';
+  return str;
+}
+
+mongoose.connection.once('open', function() {
+  Watch.find({ status: 'approved' }, function(err, watches) {
+    if (err) {
+      console.error('DB error:', err.message);
+      process.exit(1);
+    }
+
+    console.log('');
+    console.log(pad('#', 4) + pad('Permalink', 22) + pad('Title', 30) + 'Qualities');
+    console.log(new Array(80).join('-'));
+
+    watches.forEach(function(w, i) {
+      var qs = ['sd', 'hd', 'fhd', 'uhd'];
+      var badges = qs.map(function(q) {
+        var m = (w.magnet && w.magnet[q]) ? 'M' : '-';
+        var s = (w.webseed && w.webseed[q]) ? 'W' : '-';
+        return q.toUpperCase() + '[' + m + s + ']';
+      }).join(' ');
+
+      console.log(
+        pad(i + 1, 4) +
+        pad(w.permalink, 22) +
+        pad(w.title.substring(0, 28), 30) +
+        badges
+      );
+    });
+
+    console.log('');
+    console.log('Legend: M=magnet, W=webseed');
+    mongoose.connection.close(function() {
+      process.exit(0);
+    });
+  });
+});

--- a/libreflix-seeder.service
+++ b/libreflix-seeder.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Libreflix Seeder Daemon
+After=network.target
+
+[Service]
+Type=simple
+User=libreflix
+WorkingDirectory=/home/decko/dev/libreflix
+ExecStart=/usr/bin/node /home/decko/dev/libreflix/bin/libreflix daemon
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+Environment="NODE_ENV=production"
+Environment="SEEDER_DIR=/var/lib/libreflix/seeder-downloads"
+Environment="LIBREFLIX_DAEMON_PORT=9876"
+#Environment="MONGODB_URI=mongodb://localhost/libreflix"
+
+[Install]
+WantedBy=multi-user.target

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "start": "node server.js",
     "start-dev": "nodemon server.js"
   },
+  "bin": {
+    "libreflix": "./bin/libreflix"
+  },
   "dependencies": {
     "async": "^1.5.2",
     "bcrypt-nodejs": "^0.0.3",
@@ -38,7 +41,8 @@
     "passport-github": "^1.1.0",
     "passport-local": "^1.0.0",
     "passport-twitter": "^1.0.4",
-    "uuid": "^3.1.0"
+    "uuid": "^3.1.0",
+    "webtorrent": "^2.8.5"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
## Summary

Add a headless WebTorrent daemon controlled via a CLI tool to help seed content for the Libreflix streaming platform.

## Changes

- **`bin/libreflix`** — CLI entry point with commands: `daemon`, `list-content`, `seed`, `stop`, `status`
- **`cli/daemon.js`** — Long-running WebTorrent daemon listening on a local HTTP API (port 9876)
- **`cli/list-content.js`** — Queries the database and prints approved titles with quality availability
- **`libreflix-seeder.service`** — systemd unit to run the daemon on boot
- **`package.json`** — Added `bin` entry and `webtorrent` dependency

## Architecture

The seeder uses a daemon + client pattern. The daemon connects to the existing MongoDB, reads `Watch` documents, and seeds content via WebTorrent. The CLI sends commands to the daemon over HTTP:

```
libreflix daemon             # Start the seeder daemon
libreflix list-content       # List approved content
libreflix seed <permalink>   # Start seeding a title
libreflix stop <permalink>   # Stop seeding
libreflix status             # Show active torrents
```

## Environment variables

| Variable | Default | Description |
|---|---|---|
| `MONGODB_URI` | `mongodb://localhost/libreflix` | MongoDB connection |
| `SEEDER_DIR` | `./seeder-downloads` | Download directory |
| `LIBREFLIX_DAEMON_PORT` | `9876` | HTTP API port |

## Setup

```bash
npm install
npm link                              # makes "libreflix" available globally
sudo useradd --system --home /var/lib/libreflix --create-home libreflix
sudo mkdir -p /var/lib/libreflix/seeder-downloads
sudo cp libreflix-seeder.service /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now libreflix-seeder
```